### PR TITLE
feat #17: AddSchedule 페이지에 데이터 렌더 완료, 스케줄박스 gap 속성 설정 완료

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,5 +1,5 @@
 import axios,{ AxiosInstance, AxiosResponse} from "axios";
-import { ClassType } from "../types/ClassType";
+import { ScheduleType } from "../types/ScheduleType";
 
 const DEFAULT_URL = "http://localhost:8000/classes";
 
@@ -14,7 +14,7 @@ export const deleteSchedule= async (id:number) => {
     await classService.delete(`/${id}`);
 }
 
-export const postSchedule = async <T>(schedule : ClassType) : Promise<T> => {
+export const postSchedule = async <T>(schedule : ScheduleType) : Promise<T> => {
     const response : AxiosResponse<T> = await classService.post("",schedule);
     return response.data;
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3,18 +3,13 @@ import { ScheduleType } from "../types/ScheduleType";
 
 const DEFAULT_URL = "http://localhost:8000/classes";
 
-const classService : AxiosInstance = axios.create({baseURL: `${DEFAULT_URL}`});
-
-export const getScheduleByDate = async <T>(dateUrl : string = "") : Promise<T>=> {
-    const response : AxiosResponse<T> = await classService.get(`?date=${dateUrl}`);
-    return response.data;
-}
+export const scheduleService : AxiosInstance = axios.create({baseURL: `${DEFAULT_URL}`});
 
 export const deleteSchedule= async (id:number) => {
-    await classService.delete(`/${id}`);
+    await scheduleService.delete(`/${id}`);
 }
 
 export const postSchedule = async <T>(schedule : ScheduleType) : Promise<T> => {
-    const response : AxiosResponse<T> = await classService.post("",schedule);
+    const response : AxiosResponse<T> = await scheduleService.post("",schedule);
     return response.data;
 }

--- a/src/components/DailySchedule.tsx
+++ b/src/components/DailySchedule.tsx
@@ -1,26 +1,19 @@
-import React from "react";
-import { getScheduleByDate } from "../api/api";
 import ScheduleBox from "./ScheduleBox";
 import { ScheduleType } from "../types/ScheduleType";
 import styled from "styled-components";
 
 type Props = {
-  date: string;
+  dailyData: ScheduleType[];
 };
 
 const DailySchedule = (props: Props) => {
-  const { date } = props;
-  const [schedules, setSchedules] = React.useState<ScheduleType[]>([]);
-
-  React.useEffect(() => {
-    getScheduleByDate<ScheduleType[]>(date).then((data) => setSchedules(data));
-  }, [date]);
+  const { dailyData } = props;
 
   return (
     <ScheduleContainer>
-      {schedules.map((classTime: ScheduleType, index: number) => {
-        const time = `${classTime.startTime} ${classTime.startTimeAMorPM}-${classTime.endTime}`;
-        return <ScheduleBox key={index} time={time} id={classTime.id}/>;
+      {dailyData?.map((data: ScheduleType, index: number) => {
+        const time = `${data.startTime} ${data.startTimeAMorPM}-${data.endTime}`;
+        return <ScheduleBox key={index} time={time} id={data.id}/>;
       })}
     </ScheduleContainer>
   );

--- a/src/components/DailySchedule.tsx
+++ b/src/components/DailySchedule.tsx
@@ -1,25 +1,24 @@
 import React from "react";
 import { getScheduleByDate } from "../api/api";
 import ScheduleBox from "./ScheduleBox";
-import { ClassType } from "../types/ClassType";
+import { ScheduleType } from "../types/ScheduleType";
 import styled from "styled-components";
 
 type Props = {
   date: string;
 };
 
-//TODO : 스케줄박스 사이사이 띄우기
 const DailySchedule = (props: Props) => {
   const { date } = props;
-  const [schedules, setSchedules] = React.useState<ClassType[]>([]);
+  const [schedules, setSchedules] = React.useState<ScheduleType[]>([]);
 
   React.useEffect(() => {
-    getScheduleByDate<ClassType[]>(date).then((data) => setSchedules(data));
+    getScheduleByDate<ScheduleType[]>(date).then((data) => setSchedules(data));
   }, [date]);
 
   return (
     <ScheduleContainer>
-      {schedules.map((classTime: ClassType, index: number) => {
+      {schedules.map((classTime: ScheduleType, index: number) => {
         const time = `${classTime.startTime} ${classTime.startTimeAMorPM}-${classTime.endTime}`;
         return <ScheduleBox key={index} time={time} id={classTime.id}/>;
       })}
@@ -32,4 +31,7 @@ export default DailySchedule;
 const ScheduleContainer = styled.div`
   margin: 10px 0;
   padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap:20px;
 `;

--- a/src/components/HourDropDown.tsx
+++ b/src/components/HourDropDown.tsx
@@ -13,7 +13,7 @@ const HourDropDown = () => {
     setHour(value);
     setIsOpen(false);
   };
-  console.log(selectedHour);
+  // console.log(selectedHour);
   const options = ['00', '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11'];
 
   return (

--- a/src/components/MinDropDown.tsx
+++ b/src/components/MinDropDown.tsx
@@ -13,7 +13,7 @@ const MinDropDown = () => {
     setMinute(value);
     setIsOpen(false);
   };
-  console.log(selectedMinute);
+  // console.log(selectedMinute);
   const options = ['00', '05', '10', '15', '20', '25', '30', '35', '40', '45', '50', '55'];
 
   return (

--- a/src/components/ScheduleBox.tsx
+++ b/src/components/ScheduleBox.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "styled-components";
 
 type Props = {
@@ -7,9 +6,10 @@ type Props = {
   id: number;
 };
 
+//time은 startTime과 endTime, am,pm 들을 단순히 이은 string
 const ScheduleBox = (props: Props) => {
   const { time, id } = props;
-  // console.log(time, id); id는 delete할때 필요
+  //id는 delete할때 필요
   
   return (
     <ScheduleBoxContainer>

--- a/src/components/ScheduleBox.tsx
+++ b/src/components/ScheduleBox.tsx
@@ -8,10 +8,9 @@ type Props = {
 };
 
 const ScheduleBox = (props: Props) => {
-
-
   const { time, id } = props;
-  console.log(time, id);
+  // console.log(time, id); id는 delete할때 필요
+  
   return (
     <ScheduleBoxContainer>
       <ScheduleText>{time}</ScheduleText>

--- a/src/layout/DailyContainer.tsx
+++ b/src/layout/DailyContainer.tsx
@@ -1,11 +1,12 @@
 import styled from "styled-components";
 
 type Props = {
-    children: React.ReactNode;
-}
+  children: React.ReactNode;
+};
 
 export const DailyContainerDiv = styled.div`
-  width: 185.3px; //원래 = 195px 
+  position: relative;
+  width: 185.3px;
   min-height: 340px;
   padding-top: 20px;
   background: #ffffff;
@@ -15,4 +16,17 @@ export const DailyContainerDiv = styled.div`
   flex-direction: column;
 `;
 
-export const DailyContainer = (props: Props) => <DailyContainerDiv>{props.children}</DailyContainerDiv>
+const HorizontalLine = styled.div`
+  position: absolute;
+  width: inherit;
+  text-align: center;
+  border-bottom: 1px solid #b4b4b4;
+  top: 40px;
+`;
+
+export const DailyContainer = (props: Props) => (
+  <DailyContainerDiv>
+    <HorizontalLine />
+    {props.children}
+  </DailyContainerDiv>
+);

--- a/src/layout/WhiteContainer.tsx
+++ b/src/layout/WhiteContainer.tsx
@@ -1,15 +1,13 @@
 import styled from "styled-components";
 
 export const WhiteContainer = styled.div`
-  width: 95%; //1298px랑 거의 같음
-  height: 340px; //이게 맞나?
+  width: 95%; //1298px
+  height: 340px;
   background: #ffffff;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.25); /* view 같은 그림자 있으면 좋을 듯 */
-  /* left: calc(50% - 195.71px/2 - 586.14px);
-top: calc(50% - 340px/2 - 95px); 피그마에서는 마진 대신 position absolute으로 했음 */
+  box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.25);
 `;

--- a/src/pages/AddSchedule.tsx
+++ b/src/pages/AddSchedule.tsx
@@ -1,8 +1,12 @@
+import React from "react";
 import styled from "styled-components";
 import Button from "../components/Button";
 import { WhiteContainer } from "../layout/WhiteContainer";
-
-import { PageContainer, PageTitle, ElementContainer } from "../styles/page.style";
+import {
+  PageContainer,
+  PageTitle,
+  ElementContainer,
+} from "../styles/page.style";
 import { areIntervalsOverlapping, addMinutes } from "date-fns";
 import WEEK_ARRAY from "../utils/weekArray";
 import { useRecoilValue } from "recoil";
@@ -11,13 +15,14 @@ import { DayButton } from "../layout/DayButton";
 import HourDropDown from "../components/HourDropDown";
 import MinDropDown from "../components/MinDropDown";
 import AmPmButton from "../components/AmPmButton";
+import { getScheduleByDate } from "../api/api";
+import { ScheduleType } from "../types/ScheduleType";
 
 type Props = {};
 
 const AddSchedule = (props: Props) => {
   const startTime = new Date(2014, 1, 10, 1, 0);
   const endTime = addMinutes(startTime, 40);
-
   // console.log(endTime);
   const trueOrFalse = areIntervalsOverlapping(
     { start: startTime, end: endTime },
@@ -32,6 +37,14 @@ const AddSchedule = (props: Props) => {
   // console.log(trueOrFalse);
 
   const week = useRecoilValue<Date[]>(weekState);
+  const [scheduleTables, setSchedulesTables] = React.useState<ScheduleType[]>([]);
+
+  const onClickGetSchedule = (date:string) => {
+    getScheduleByDate<ScheduleType[]>(date).then((data) => setSchedulesTables(data));
+  };
+
+  console.log(scheduleTables); //각 날짜에 있는 모든 스케줄 불러옴 [{id, startTime, endTime, date}, ... ]
+  /* 사용할 때 scheduleTables map 돌려서 각각의 startTime, endTime 갖고 overlap 함수에 넣었다가 결과 모으면 될듯 */
 
   return (
     <PageContainer>
@@ -52,10 +65,8 @@ const AddSchedule = (props: Props) => {
             <AmPmButton handleClick={handlePmClick}>PM</AmPmButton>
           </DropDownContainer>
         </StartTimeContainer>
-    
-        
 
-        <div style={{ display: "flex" }}>
+        <Positioner>
           <RepeatOnText>Repeat on</RepeatOnText>
           {week.map((day: Date, index: number) => {
             return (
@@ -64,6 +75,7 @@ const AddSchedule = (props: Props) => {
                 date={day.toLocaleDateString()}
                 onClick={() => {
                   console.log(day.toLocaleDateString());
+                  onClickGetSchedule(day.toLocaleDateString());
                   // onClick시 버튼안에 있는 date를 post 할 데이터에 추가하는 로직 여기에
                 }}
               >
@@ -71,7 +83,7 @@ const AddSchedule = (props: Props) => {
               </DayButton>
             );
           })}
-        </div>
+        </Positioner>
       </WhiteContainer>
       <ButtonContainer>
         <Button>Save</Button>
@@ -89,6 +101,10 @@ const TitleContainer = styled(ElementContainer)`
 const ButtonContainer = styled(ElementContainer)`
   justify-content: flex-end;
 `;
+
+const Positioner = styled.div`
+  display: flex;
+`
 
 const StartTimeContainer = styled.div`
   width: 100%;
@@ -120,8 +136,7 @@ const ColoneText = styled.div`
   position: absolute;
   /* top: 205px;
   left: 250px; */
-`
-
+`;
 
 const RepeatOnText = styled.div`
   display: flex;

--- a/src/pages/AddSchedule.tsx
+++ b/src/pages/AddSchedule.tsx
@@ -10,12 +10,11 @@ import {
 import { areIntervalsOverlapping, addMinutes } from "date-fns";
 import WEEK_ARRAY from "../utils/weekArray";
 import { useRecoilValue } from "recoil";
-import { weekState } from "../store/weekAtom";
+import { weekState, scheduleState } from "../store/weekAtom";
 import { DayButton } from "../layout/DayButton";
 import HourDropDown from "../components/HourDropDown";
 import MinDropDown from "../components/MinDropDown";
 import AmPmButton from "../components/AmPmButton";
-import { getScheduleByDate } from "../api/api";
 import { ScheduleType } from "../types/ScheduleType";
 
 type Props = {};
@@ -37,15 +36,10 @@ const AddSchedule = (props: Props) => {
   // console.log(trueOrFalse);
 
   const week = useRecoilValue<Date[]>(weekState);
-  const [scheduleTables, setSchedulesTables] = React.useState<ScheduleType[]>([]);
+  const schedules = useRecoilValue<ScheduleType[]>(scheduleState);
 
-  const onClickGetSchedule = (date:string) => {
-    getScheduleByDate<ScheduleType[]>(date).then((data) => setSchedulesTables(data));
-  };
-
-  console.log(scheduleTables); //각 날짜에 있는 모든 스케줄 불러옴 [{id, startTime, endTime, date}, ... ]
-  /* 사용할 때 scheduleTables map 돌려서 각각의 startTime, endTime 갖고 overlap 함수에 넣었다가 결과 모으면 될듯 */
-
+  console.log(schedules); //각 날짜에 있는 모든 스케줄 불러옴 [{id, startTime, endTime, date}, ... ]
+  
   return (
     <PageContainer>
       <TitleContainer>
@@ -75,7 +69,6 @@ const AddSchedule = (props: Props) => {
                 date={day.toLocaleDateString()}
                 onClick={() => {
                   console.log(day.toLocaleDateString());
-                  onClickGetSchedule(day.toLocaleDateString());
                   // onClick시 버튼안에 있는 date를 post 할 데이터에 추가하는 로직 여기에
                 }}
               >

--- a/src/pages/WeeklySchedule.tsx
+++ b/src/pages/WeeklySchedule.tsx
@@ -16,7 +16,6 @@ const WeeklySchedule = () => {
   //testPost, testDelete는 삭제 예정
   const testPost = () => {
     postSchedule({
-
       id:100,
       startTime:"10:00",
       endTime:"10:40",
@@ -36,7 +35,6 @@ const WeeklySchedule = () => {
         <Button>Add Class Schedule</Button>
       </TitleAndButtonContainer>
       <MainContainer>
-        <HorizontalLine />
         {week.map((day: Date, index: number) => {
           return (
             <DailyContainer key={index}>
@@ -60,14 +58,4 @@ const TitleAndButtonContainer = styled(ElementContainer)`
 
 const MainContainer = styled.div`
   display: flex;
-
-`; 
-
-const HorizontalLine = styled.div`
-  position: absolute;
-  width: 90%;
-  text-align: center;
-  border-bottom: 1px solid #b4b4b4;
-  top: calc(50% - 105px);
-  left: 70px;
 `;

--- a/src/pages/WeeklySchedule.tsx
+++ b/src/pages/WeeklySchedule.tsx
@@ -1,17 +1,18 @@
-import React from "react";
 import Button from "../components/Button";
 import { DailyContainer } from "../layout/DailyContainer";
 import styled from "styled-components";
 import { useRecoilValue } from "recoil";
-import { weekState } from "../store/weekAtom";
+import { weekState, scheduleState } from "../store/weekAtom";
 import { DayTitle } from "../layout/DayTitle";
 import DailySchedule from "../components/DailySchedule";
 import { postSchedule,deleteSchedule } from "../api/api";
 import { PageContainer, PageTitle, ElementContainer } from "../styles/page.style";
+import { ScheduleType } from "../types/ScheduleType";
 import WEEK_ARRAY from "../utils/weekArray";
 
 const WeeklySchedule = () => {
   const week = useRecoilValue<Date[]>(weekState);
+  const schedule = useRecoilValue<ScheduleType[]>(scheduleState);
 
   //testPost, testDelete는 삭제 예정
   const testPost = () => {
@@ -39,7 +40,7 @@ const WeeklySchedule = () => {
           return (
             <DailyContainer key={index}>
               <DayTitle>{WEEK_ARRAY[day.getDay()]}</DayTitle>
-              <DailySchedule date={day.toLocaleDateString()} />
+              <DailySchedule dailyData={schedule.filter((each)=>(each.date === day.toLocaleDateString()))} />
             </DailyContainer>
           );
         })}

--- a/src/store/weekAtom.ts
+++ b/src/store/weekAtom.ts
@@ -24,18 +24,3 @@ export const weekState = atom({
   key: "weekState",
   default: getWeekStateSelector,
 });
-
-const getScheduleSelector = selector({
-  key: "getScheduleSelector",
-  get:({get})=>{
-    const weekData = get(weekState); //[Date객체월, Date객체화, ...]
-    const data = [];
-  
-  }
-})
-
-export const scheduleState = atom({
-  key: "scheduleState",
-  default: getScheduleSelector
-});
-

--- a/src/store/weekAtom.ts
+++ b/src/store/weekAtom.ts
@@ -1,5 +1,6 @@
 import { atom, selector } from "recoil";
 import { getDay, toDate, addDays } from "date-fns";
+import { scheduleService } from "../api/api";
 
 const getWeekStateSelector = selector({
   key: "getWeekStateSelector",
@@ -7,7 +8,7 @@ const getWeekStateSelector = selector({
     const now: Date = new Date();
     const day: number = getDay(now);
     const mondayMilliseconds: number = now.setDate(now.getDate() - (day - 1));
-    const monday : Date = toDate(mondayMilliseconds);
+    const monday: Date = toDate(mondayMilliseconds);
     return [
       monday,
       addDays(monday, 1),
@@ -23,4 +24,25 @@ const getWeekStateSelector = selector({
 export const weekState = atom({
   key: "weekState",
   default: getWeekStateSelector,
+});
+
+const getScheduleSelector = selector({
+  key: "getScheduleSelector",
+  get: async ({ get }) => {
+    const weekData = get(weekState);
+    const requestUrlString = `?date_gte=${weekData[0].toLocaleDateString()}&date_lte=${weekData[
+      weekData.length - 1
+    ].toLocaleDateString()}`;
+    const weekSchedule = await scheduleService
+      .get(requestUrlString)
+      .then((response) => {
+        return response.data;
+      });
+    return weekSchedule;
+  },
+});
+
+export const scheduleState = atom({
+  key: "scheduleState",
+  default: getScheduleSelector,
 });

--- a/src/types/ScheduleType.ts
+++ b/src/types/ScheduleType.ts
@@ -1,4 +1,4 @@
-export type ClassType = {
+export type ScheduleType = {
   id: number;
   startTime: string;
   endTime: string;


### PR DESCRIPTION
- 스케줄 데이터 recoil로 전역 상태 관리 실패 => AddSchedule 페이지에 가져올 수 있게 onClickGetSchedule 함수 구현
- WeeklySchedule 페이지에서 Schedule박스 사이 gap 속성 완료